### PR TITLE
Ensure the parser consumed the full JsonPath

### DIFF
--- a/jsonpath4k/src/commonMain/antlr/JsonPathParser.g4
+++ b/jsonpath4k/src/commonMain/antlr/JsonPathParser.g4
@@ -5,7 +5,7 @@ parser grammar JsonPathParser;
 
 options { tokenVocab=JsonPathLexer; }
 
-jsonpath_query      : rootIdentifier segments;
+jsonpath_query      : rootIdentifier segments EOF;
 segments            : (ws segment)*;
 segment             : bracketed_selection | SHORTHAND_SELECTOR shorthand_segment | DESCENDANT_SELECTOR descendant_segment;
 shorthand_segment   : wildcardSelector | memberNameShorthand;

--- a/jsonpath4k/src/commonTest/kotlin/at/asitplus/jsonpath/JsonPathUnitTest.kt
+++ b/jsonpath4k/src/commonTest/kotlin/at/asitplus/jsonpath/JsonPathUnitTest.kt
@@ -2,6 +2,7 @@ package at.asitplus.jsonpath
 
 import at.asitplus.jsonpath.core.JsonPathFilterExpressionType
 import at.asitplus.jsonpath.core.JsonPathFunctionExtension
+import at.asitplus.jsonpath.implementation.JsonPathParserException
 import at.asitplus.jsonpath.implementation.JsonPathTypeCheckerException
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
@@ -1241,6 +1242,14 @@ class JsonPathUnitTest : FreeSpec({
                     val nodeList = JsonPath(this.testScope.testCase.name.originalName)
                         .query(jsonElement).map { it.value }
                     nodeList shouldHaveSize 0
+                }
+            }
+        }
+
+        "RMLTC0002g-JSON" - {
+            "$.students[*]]" {
+                shouldThrow<JsonPathParserException> {
+                    JsonPath(this.testScope.testCase.name.originalName)
                 }
             }
         }


### PR DESCRIPTION
There was no way of knowing if a JSON Path was fully consumed by the parser.
This allowed JSON Paths with invalid trailing syntax to silently pass, such as:
```
$.students[*]]
```
From my understanding of the RFC 9535, we have a root node identifier, followed by a valid segment, then an invalid `]` segment.