### PR TITLE
Hotfix/3.0.1: Validate whether whole string has been consumed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Release 3.0.1
+ * Fix: Validates whether the whole string has been consumed
+
 # Release 3.0.0
  * BREAKING CHANGES:
    * Removed template type from `JsonPathFunctionExtension`

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ kotlin.native.ignoreDisabledTargets=true
 # workaround dokka bug (need to wait for next snapshot build)
 org.jetbrains.dokka.classpath.excludePlatformDependencyFiles=true
 
-artifactVersion = 3.0.0
+artifactVersion = 3.0.1
 jdk.version=17
 
 android.experimental.lint.version=8.5.0

--- a/jsonpath4k/src/commonMain/antlr/JsonPathParser.g4
+++ b/jsonpath4k/src/commonMain/antlr/JsonPathParser.g4
@@ -5,7 +5,7 @@ parser grammar JsonPathParser;
 
 options { tokenVocab=JsonPathLexer; }
 
-jsonpath_query      : rootIdentifier segments;
+jsonpath_query      : rootIdentifier segments EOF;
 segments            : (ws segment)*;
 segment             : bracketed_selection | SHORTHAND_SELECTOR shorthand_segment | DESCENDANT_SELECTOR descendant_segment;
 shorthand_segment   : wildcardSelector | memberNameShorthand;

--- a/jsonpath4k/src/commonTest/kotlin/at/asitplus/jsonpath/JsonPathUnitTest.kt
+++ b/jsonpath4k/src/commonTest/kotlin/at/asitplus/jsonpath/JsonPathUnitTest.kt
@@ -2,6 +2,7 @@ package at.asitplus.jsonpath
 
 import at.asitplus.jsonpath.core.JsonPathFilterExpressionType
 import at.asitplus.jsonpath.core.JsonPathFunctionExtension
+import at.asitplus.jsonpath.implementation.JsonPathParserException
 import at.asitplus.jsonpath.implementation.JsonPathTypeCheckerException
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
@@ -1241,6 +1242,14 @@ class JsonPathUnitTest : FreeSpec({
                     val nodeList = JsonPath(this.testScope.testCase.name.originalName)
                         .query(jsonElement).map { it.value }
                     nodeList shouldHaveSize 0
+                }
+            }
+        }
+
+        "RMLTC0002g-JSON" - {
+            "$.students[*]]" {
+                shouldThrow<JsonPathParserException> {
+                    JsonPath(this.testScope.testCase.name.originalName)
                 }
             }
         }


### PR DESCRIPTION
This is part of validating whether a json path is well formed