### PR TITLE
Change: Lower Android minSdk from 30 to 21 and bump to 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+# Release 3.2.0
+ * Change: Lower Android `minSdk` from 30 to 21
+
 # Release 3.1.0
  * Add: structural equality check for `NormalizedJsonPath` and `NormalizedJsonPathSegment` 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-# Release 3.2.0
+# Release 3.1.1
  * Change: Lower Android `minSdk` from 30 to 21
 
 # Release 3.1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ kotlin.native.ignoreDisabledTargets=true
 # workaround dokka bug (need to wait for next snapshot build)
 org.jetbrains.dokka.classpath.excludePlatformDependencyFiles=true
 
-artifactVersion = 3.2.0
+artifactVersion = 3.1.1
 jdk.version=17
 
 android.experimental.lint.version=8.5.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ kotlin.native.ignoreDisabledTargets=true
 # workaround dokka bug (need to wait for next snapshot build)
 org.jetbrains.dokka.classpath.excludePlatformDependencyFiles=true
 
-artifactVersion = 3.1.0
+artifactVersion = 3.2.0
 jdk.version=17
 
 android.experimental.lint.version=8.5.0

--- a/jsonpath4k/build.gradle.kts
+++ b/jsonpath4k/build.gradle.kts
@@ -136,7 +136,7 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
     defaultConfig {
-        minSdk = 30
+        minSdk = 21
     }
 }
 


### PR DESCRIPTION
Related to #54.
This way, it allows consumers to update to latest version